### PR TITLE
SOLUTIONS-162: Support eids in adapter

### DIFF
--- a/modules/outbrainBidAdapter.js
+++ b/modules/outbrainBidAdapter.js
@@ -40,6 +40,7 @@ export const spec = {
     const publisher = setOnAny(validBidRequests, 'params.publisher');
     const bcat = setOnAny(validBidRequests, 'params.bcat');
     const badv = setOnAny(validBidRequests, 'params.badv');
+    const eids = setOnAny(validBidRequests, 'userIdAsEids')
     const cur = CURRENCY;
     const endpointUrl = config.getConfig('outbrain.bidderUrl');
     const timeout = bidderRequest.timeout;
@@ -103,6 +104,10 @@ export const spec = {
     }
     if (config.getConfig('coppa') === true) {
       deepSetValue(request, 'regs.coppa', config.getConfig('coppa') & 1)
+    }
+
+    if (eids) {
+      deepSetValue(request, 'user.ext.eids', eids);
     }
 
     return {

--- a/test/spec/modules/outbrainBidAdapter_spec.js
+++ b/test/spec/modules/outbrainBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/outbrainBidAdapter.js';
 import {config} from 'src/config.js';
 import {server} from 'test/mocks/xhr';
+import { createEidsArray } from 'modules/userId/eids.js';
 
 describe('Outbrain Adapter', function () {
   describe('Bid request and response', function () {
@@ -343,6 +344,23 @@ describe('Outbrain Adapter', function () {
         expect(resData.regs.coppa).to.equal(1)
 
         config.resetConfig()
+      });
+
+      it('should pass extended ids', function () {
+        let bidRequest = {
+          bidId: 'bidId',
+          params: {},
+          userIdAsEids: createEidsArray({
+            idl_env: 'id-value',
+          }),
+          ...commonBidRequest,
+        };
+
+        let res = spec.buildRequests([bidRequest], commonBidderRequest);
+        const resData = JSON.parse(res.data)
+        expect(resData.user.ext.eids).to.deep.equal([
+          {source: 'liveramp.com', uids: [{id: 'id-value', atype: 3}]}
+        ]);
       });
     })
 


### PR DESCRIPTION
This PR add support for passing all available eids to our bidder. This means we won't need to change the adapter every time we add support for a new identity provider.