### PR TITLE
GOOF-31: support for multiple bid requests based on impression type 

### DIFF
--- a/modules/outbrainBidAdapter.js
+++ b/modules/outbrainBidAdapter.js
@@ -143,7 +143,7 @@ export const spec = {
         method: 'POST',
         url: endpointUrl,
         data: JSON.stringify(Object.assign(request, {'imp': nativeImps})),
-        bids: nativeImps
+        bids: validBidRequests.filter(item => item.nativeParams != null)
       })
     }
     if (displayImps.length > 0) {
@@ -151,7 +151,7 @@ export const spec = {
         method: 'POST',
         url: endpointUrl,
         data: JSON.stringify(Object.assign(request, {'imp': displayImps})),
-        bids: displayImps
+        bids: validBidRequests.filter(item => item.nativeParams == null)
       })
     }
 

--- a/test/spec/modules/outbrainBidAdapter_spec.js
+++ b/test/spec/modules/outbrainBidAdapter_spec.js
@@ -3,7 +3,6 @@ import {spec} from 'modules/outbrainBidAdapter.js';
 import {config} from 'src/config.js';
 import {server} from 'test/mocks/xhr';
 import { createEidsArray } from 'modules/userId/eids.js';
-import common from 'mocha/lib/interfaces/common';
 
 describe('Outbrain Adapter', function () {
   describe('Bid request and response', function () {

--- a/test/spec/modules/outbrainBidAdapter_spec.js
+++ b/test/spec/modules/outbrainBidAdapter_spec.js
@@ -246,9 +246,41 @@ describe('Outbrain Adapter', function () {
             }
           ]
         }
+        const expectedBids = [
+          {
+            auctionId: '12043683-3254-4f74-8934-f941b085579e',
+            bidId: '2d6815a92ba1ba',
+            bidder: 'outbrain',
+            nativeParams: {
+              image: {
+                required: true,
+                sendId: true,
+                sizes: [
+                  120,
+                  100
+                ]
+              },
+              sponsoredBy: {
+                required: false
+              },
+              title: {
+                required: true,
+                sendId: true
+              }
+            },
+            netRevenue: 'net',
+            params: {
+              publisher: {
+                'id': 'publisher-id'
+              }
+            }
+          }
+        ]
+
         const res = spec.buildRequests([bidRequest], commonBidderRequest)[0]
         expect(res.url).to.equal('https://bidder-url.com')
         expect(res.data).to.deep.equal(JSON.stringify(expectedData))
+        expect(res.bids).to.deep.equal(expectedBids)
       });
 
       it('should build display request', function () {
@@ -293,9 +325,30 @@ describe('Outbrain Adapter', function () {
             }
           ]
         }
+        const expectedBids = [
+          {
+            auctionId: '12043683-3254-4f74-8934-f941b085579e',
+            bidId: '2d6815a92ba1ba',
+            bidder: 'outbrain',
+            netRevenue: 'net',
+            params: {
+              publisher: {
+                id: 'publisher-id'
+              }
+            },
+            sizes: [
+              [
+                300,
+                250
+              ]
+            ]
+          }
+        ]
+
         const res = spec.buildRequests([bidRequest], commonBidderRequest)[0]
         expect(res.url).to.equal('https://bidder-url.com')
         expect(res.data).to.deep.equal(JSON.stringify(expectedData))
+        expect(res.bids).to.deep.equal(expectedBids)
       })
 
       it('should build native AND display requests', function () {
@@ -366,8 +419,39 @@ describe('Outbrain Adapter', function () {
             }
           ]
         };
+        const nativeExpectedBids = [
+          {
+            auctionId: '12043683-3254-4f74-8934-f941b085579e',
+            bidId: '2d6815a92ba1ba',
+            bidder: 'outbrain',
+            nativeParams: {
+              image: {
+                required: true,
+                sendId: true,
+                sizes: [
+                  120,
+                  100
+                ]
+              },
+              sponsoredBy: {
+                required: false
+              },
+              title: {
+                required: true,
+                sendId: true
+              }
+            },
+            netRevenue: 'net',
+            params: {
+              publisher: {
+                'id': 'publisher-id'
+              }
+            }
+          }
+        ]
         expect(nativeRequest.url).to.equal('https://bidder-url.com')
         expect(nativeRequest.data).to.deep.equal(JSON.stringify(nativeExpectedData))
+        expect(nativeRequest.bids).to.deep.equal(nativeExpectedBids)
         const displayExpectedData = {
           site: {
             page: 'https://example.com/',
@@ -405,8 +489,28 @@ describe('Outbrain Adapter', function () {
             }
           ]
         }
+        const displayExpectedBids = [
+          {
+            auctionId: '12043683-3254-4f74-8934-f941b085579e',
+            bidId: '2d6815a92ba1ba',
+            bidder: 'outbrain',
+            netRevenue: 'net',
+            params: {
+              publisher: {
+                id: 'publisher-id'
+              }
+            },
+            sizes: [
+              [
+                300,
+                250
+              ]
+            ]
+          }
+        ]
         expect(displayRequest.url).to.equal('https://bidder-url.com')
         expect(displayRequest.data).to.deep.equal(JSON.stringify(displayExpectedData))
+        expect(displayRequest.bids).to.deep.equal(displayExpectedBids)
       })
 
       it('should pass optional parameters in request', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Our bidder does not support multiformat bid requests, so we made a change to send 2 bid requests - one for native imps and one for display imps